### PR TITLE
Add Lock() method for Mutex.

### DIFF
--- a/sync/mutex/mutex.go
+++ b/sync/mutex/mutex.go
@@ -66,6 +66,12 @@ type Locked[T any] struct {
 
 // Value returns a reference to the protected value. It must not be used after
 // calling Unlock.
+//
+// Value will panic if called after Unlock()
+//
+// We recommend against assigning the result of Value() to a variable; while
+// repeatedly having to write l.Value() is mildly annoying, it makes it
+// much harder to accidentally use the value after unlocking.
 func (l *Locked[T]) Value() *T {
 	if l.unlocked {
 		panic("Called Locked.Value after Unlock.")

--- a/sync/mutex/mutex.go
+++ b/sync/mutex/mutex.go
@@ -24,6 +24,17 @@ func (m *Mutex[T]) With(f func(*T)) {
 	f(&m.val)
 }
 
+// Lock acquires the mutex and returns a reference to the value. Call Unlock()
+// on the return value to release the lock.
+//
+// Where possible, you should prefer using Mutex.With and similar functions. If
+// those are insufficient to handle your use case consider whether your locking
+// scheme is too complicated before going ahead and using this.
+func (m *Mutex[T]) Lock() *Locked[T] {
+	m.mu.Lock()
+	return &Locked[T]{mu: m}
+}
+
 // With1(m, ...) is like m.With(...), except that the callback returns
 // a value.
 func With1[T, A any](m *Mutex[T], f func(*T) A) A {
@@ -44,4 +55,30 @@ func With2[T, A, B any](m *Mutex[T], f func(*T) (A, B)) (A, B) {
 		a, b = f(t)
 	})
 	return a, b
+}
+
+// A Locked[T] is a reference to a value of type T which is guarded by a Mutex,
+// which the caller has acquired.
+type Locked[T any] struct {
+	mu       *Mutex[T]
+	unlocked bool
+}
+
+// Value returns a reference to the protected value. It must not be used after
+// calling Unlock.
+func (l *Locked[T]) Value() *T {
+	if l.unlocked {
+		panic("Called Locked.Value after Unlock.")
+	}
+	return &l.mu.val
+}
+
+// Unlock releases the mutex. Any references to the value obtained via Value
+// must not be used after this is called.
+func (l *Locked[T]) Unlock() {
+	if l.unlocked {
+		panic("Called Locked.Unlock twice.")
+	}
+	l.unlocked = true
+	l.mu.mu.Unlock()
 }

--- a/sync/mutex/mutex.go
+++ b/sync/mutex/mutex.go
@@ -87,8 +87,7 @@ func With4[T, A, B, C, D any](m *Mutex[T], f func(*T) (A, B, C, D)) (A, B, C, D)
 // A Locked[T] is a reference to a value of type T which is guarded by a Mutex,
 // which the caller has acquired.
 type Locked[T any] struct {
-	mu       *Mutex[T]
-	unlocked bool
+	mu *Mutex[T]
 }
 
 // Value returns a reference to the protected value. It must not be used after
@@ -100,18 +99,12 @@ type Locked[T any] struct {
 // repeatedly having to write l.Value() is mildly annoying, it makes it
 // much harder to accidentally use the value after unlocking.
 func (l *Locked[T]) Value() *T {
-	if l.unlocked {
-		panic("Called Locked.Value after Unlock.")
-	}
 	return &l.mu.val
 }
 
 // Unlock releases the mutex. Any references to the value obtained via Value
 // must not be used after this is called.
 func (l *Locked[T]) Unlock() {
-	if l.unlocked {
-		panic("Called Locked.Unlock twice.")
-	}
-	l.unlocked = true
 	l.mu.mu.Unlock()
+	l.mu = nil
 }

--- a/sync/mutex/mutex.go
+++ b/sync/mutex/mutex.go
@@ -57,6 +57,33 @@ func With2[T, A, B any](m *Mutex[T], f func(*T) (A, B)) (A, B) {
 	return a, b
 }
 
+// With3 is like With1, but the callback returns three values instead of one.
+func With3[T, A, B, C any](m *Mutex[T], f func(*T) (A, B, C)) (A, B, C) {
+	var (
+		a A
+		b B
+		c C
+	)
+	m.With(func(t *T) {
+		a, b, c = f(t)
+	})
+	return a, b, c
+}
+
+// With4 is like With1, but the callback returns four values instead of one.
+func With4[T, A, B, C, D any](m *Mutex[T], f func(*T) (A, B, C, D)) (A, B, C, D) {
+	var (
+		a A
+		b B
+		c C
+		d D
+	)
+	m.With(func(t *T) {
+		a, b, c, d = f(t)
+	})
+	return a, b, c, d
+}
+
 // A Locked[T] is a reference to a value of type T which is guarded by a Mutex,
 // which the caller has acquired.
 type Locked[T any] struct {


### PR DESCRIPTION
...for more complex synchronization patterns than can be accommodated by With, which unfortunately go-capnp has a few of.

---

@lthibault, I am looking to use this package to guard some state in go-capnp, and there are some non-hierarchical patterns used in Client/clientHook. I'd like to remove those, but I don't want to do so while also swapping in this implementation, so this PR makes this package expressive enough to support current patterns, while still being less error prone. Interested in your thoughts.