### PR TITLE
Bug/atomic alignment

### DIFF
--- a/rc/ref.go
+++ b/rc/ref.go
@@ -17,8 +17,8 @@ type Ref[T any] struct {
 
 // Container for the actual data; Ref just points to this.
 type cell[T any] struct {
+	refcount int32  // The refernce count; MUST aligned.
 	value    T      // The actual value that is stored.
-	refcount int32  // The refernce count.
 	release  func() // Function to call when refcount hits zero.
 }
 


### PR DESCRIPTION
[This](https://pkg.go.dev/sync/atomic#pkg-note-BUG) note in the `sync/atomic` package is a bit cryptic, but I'm 85% sure that `cell.ref` was not properly aligned.