### PR TITLE
WIP: mutex: add instrumentation for debugging deadlocks

### DIFF
--- a/sync/mutex/debug.go
+++ b/sync/mutex/debug.go
@@ -1,0 +1,7 @@
+package mutex
+
+import "sync/atomic"
+
+type debugInfo struct {
+	ownerStack atomic.Pointer[string]
+}


### PR DESCRIPTION
This adds some instrumentation such that after a timeout, acquiring a mutex will panic with the stack traces of both the goroutine that is trying to acquire the lock, and the goroutine that is holding it (at the time of acquisition).

Still TODO:

- [ ] Use conditional compilation somehow; this introduces way too much overhead to be usable in prod.
- [ ] Make this work for .Lock(), rather than just .With().
- [ ] Deal with the race condition noted in the comment.