### PR TITLE
move go.mod module to github.com/zenhack/go-util

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module zenhack.net/go/util
+module github.com/zenhack/go-util
 
 go 1.19
 


### PR DESCRIPTION
`zenhack.net` is gone, so `go.mod` should point to Github, instead.